### PR TITLE
change steemit websocket

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -27,7 +27,7 @@ function calcRep(rep) {
 var BLOCKCHAINS = {
 	steem: {
 		network: 'steem',
-		websocket: 'wss://steemd.steemit.com',
+		websocket: 'wss://steemd.steemitstage.com',
 		address_prefix: 'STM',
 		chain_id: '0000000000000000000000000000000000000000000000000000000000000000',
 		steem_ticker: 'STEEM',


### PR DESCRIPTION
 steemd.steemit.com was retired january 2018 according to https://www.steem.center/index.php?title=Public_Websocket_Servers so program not loading when index is called. this pull changes the websocket to other from the list with wss owned by Steemit Inc.